### PR TITLE
Release 4.2.1-1

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,7 @@
 name: docker-publish
 on:
-  push:
-    paths:
-      - 'Dockerfile'
-      - 'start'
+  release:
+    types: [published]
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,3 +29,4 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/dabmux:latest
+                ${{ secrets.DOCKER_HUB_USERNAME }}/dabmux:$GITHUB_REF_NAME

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout 
-        uses: actions/checkout@v2
-      -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN  apt-get install --yes \
           libboost-system-dev \
           libcurl4-openssl-dev \
           libzmq3-dev  
-ARG  URL=ODR-DabMux/archive/refs/tags/v4.1.0.tar.gz
+ARG  URL=ODR-DabMux/archive/refs/tags/v4.2.1.tar.gz
 RUN  cd /root && \
      curl -L https://github.com/Opendigitalradio/${URL} | tar -xz && \
      cd ODR* && \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Introduction
 This repository is part of a project aiming at containerizing the [mmbTools](https://www.opendigitalradio.org/mmbtools) software stack of [Open Digital Radio](https://www.opendigitalradio.org/).
 
-This repository features the [dab multiplexer](https://github.com/opendigitalradio/ODR-DabMux) component. 
+This repository features the [dab multiplexer (v4.2.1)](https://github.com/opendigitalradio/ODR-DabMux) component. 
 
 ## Quick setup
 1. Get this repository on your host


### PR DESCRIPTION
### Changes

- Dockerfile uses odr-dabmux archive v4.2.1
- README.md update
- .github/workflows/docker-publish.yml modified to be triggered on published release (instead of selected file pushes) and to generate 2 docker tags (latest and release)