### PR TITLE
Prepare version 5.0.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,9 @@ name: docker-publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * 6'
 
 jobs:
   build:
@@ -10,20 +13,20 @@ jobs:
     steps:
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       -
         name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/dabmux:latest,${{ secrets.DOCKER_HUB_USERNAME }}/dabmux:${{ github.ref_name }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/dabmux:latest,${{ secrets.DOCKERHUB_USERNAME }}/dabmux:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,11 @@
-# Build odr-audioenc
-FROM ubuntu:22.04 AS builder
-ARG  URL_BASE=https://github.com/Opendigitalradio
-ARG  SOFTWARE=ODR-DabMux/archive/refs/tags
-ARG  VERSION=v4.2.1
-ENV  DEBIAN_FRONTEND=noninteractive
-## Update system
-RUN  apt-get update \
-     && apt-get upgrade --yes
-## Install build packages
-RUN  apt-get install --yes \
-          autoconf \
-          build-essential \
-          curl \
-          pkg-config
-## Install development libraries and build
-RUN  apt-get install --yes \
-          libboost-system-dev \
-          libcurl4-openssl-dev \
-          libzmq3-dev \
-     && cd /root \
-     && curl -L ${URL_BASE}/${SOFTWARE}/${VERSION}.tar.gz | tar -xz \
-     && cd ODR* \
-     && ./bootstrap.sh \
-     && ./configure \
-     && make \
-     && make install 
-
-# Build the final image
-FROM ubuntu:22.04
-ENV  DEBIAN_FRONTEND=noninteractive
-## Update system
-RUN  apt-get update \
-     && apt-get upgrade --yes
-## Copy objects built in the builder phase
-COPY --from=builder /usr/local/bin/* /usr/bin/
-COPY start /usr/local/bin/
-## Install production libraries
-RUN  chmod 0755 /usr/local/bin/start \
-     && apt-get install --yes \
-          libboost-system1.74.0 \
-          libcurl4 \
-          libzmq5 \
-          tzdata \
-     && rm -rf /var/lib/apt/lists/*
+FROM   debian:bookworm-backports
+ENV    DEBIAN_FRONTEND=noninteractive
+COPY   start /usr/local/bin/
+RUN    chmod 0755 /usr/local/bin/start \
+       && apt-get update \
+       && apt-get upgrade --yes \
+       && apt-get install --yes odr-dabmux \
+       && rm -rf /var/lib/apt/lists/*
 
 EXPOSE 9001-9016
 EXPOSE 9201

--- a/README.md
+++ b/README.md
@@ -3,27 +3,52 @@
 # opendigitalradio/docker-dabmux
 
 ## Introduction
-This repository is part of a project aiming at containerizing the [mmbTools](https://www.opendigitalradio.org/mmbtools) software stack of [Open Digital Radio](https://www.opendigitalradio.org/).
+This repository is part of a project aiming at containerizing the
+[mmbTools](https://www.opendigitalradio.org/mmbtools) software stack of
+[Open Digital Radio](https://www.opendigitalradio.org/). It features the
+[dab multiplexer](https://github.com/opendigitalradio/ODR-DabMux) component.
 
-This repository features the [dab multiplexer (v4.2.1)](https://github.com/opendigitalradio/ODR-DabMux) component. 
+You need to install [docker](https://www.docker.com) or
+[podman](https://podman.io) on your host to run the container image.
+Please adapt the instructions below, according to your choice.
 
-## Quick setup
-1. Get this repository on your host
+## How to get the container image on your host
+You can either pull the container image from the internet or build it
+yourself.
+
+### Pull the image from internet
+```
+docker image pull opendigitalradio/dabmux
+```
+
+### Build the image
+```
+git clone \
+  https://github.com/opendigitalradio/dabmux.git \
+  docker-dabmux
+cd docker-dabmux
+docker image build \
+  --tag opendigitalradio/dabmux \
+  .
+```
+
+## Setup
 1. Declare your time zone:
     ```
-    TZ=your_time_zone (ex: TZ=Europe/Zurich)
+    TZ=<your_time_zone>
     ```
 1. Declare your mux configuration file:
     ```
-    MUX_CONFIG=$(pwd)/config/odr-dabmux.info
+    MUX_CONFIG=<path_to_your_mux_configuration_file>
     ```
-1. Run the container. Please note that the image uses ports:
-    - 9001 - 9016: incoming audio/PAD streams
+1. The image exposes the following ports:
+    - 9001 - 9016: incoming encoder streams
     - 9201: output stream
     - 12720: multiplexer server management port
     - 12721: multiplexer ftp port
     - 12722: multiplexer ZMQ RC port
 
+## Run the container
     ```
     docker container run \
         --name odr-dabmux \
@@ -31,12 +56,11 @@ This repository features the [dab multiplexer (v4.2.1)](https://github.com/opend
         --rm \
         --env "TZ=${TZ}" \
         --network odr \
+        --publish 9001-9016:9001-9016 \
         --publish 9201:9201 \
-        --publish 12720:12720 \
-        --publish 12721:12721 \
-        --publish 12722:12722 \
+        --publish 12720-12722:12720-12722 \
         --volume ${MUX_CONFIG}:/config/mux.ini \
-        opendigitalradio/dabmux:latest
+        opendigitalradio/dabmux
     ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ This repository features the [dab multiplexer (v4.2.1)](https://github.com/opend
         --publish 12721:12721 \
         --publish 12722:12722 \
         --volume ${MUX_CONFIG}:/config/mux.ini \
-        opendigitalradio/dabmux:latest \
-        /config/mux.ini
+        opendigitalradio/dabmux:latest
     ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ This repository features the [dab multiplexer (v4.2.1)](https://github.com/opend
         --publish 12720:12720 \
         --publish 12721:12721 \
         --publish 12722:12722 \
-        --volume ${MUX_CONFIG}:/mnt/mux.ini \
+        --volume ${MUX_CONFIG}:/config/mux.ini \
         opendigitalradio/dabmux:latest \
-        /mnt/mux.ini
+        /config/mux.ini
     ```
 
 ## Test

--- a/start
+++ b/start
@@ -1,4 +1,12 @@
 #!/bin/bash
 
-# Start the mux
-odr-dabmux "${1}"
+argc=$#
+argv=$*
+
+set -euo pipefail
+
+if [ ${argc} -eq 0 ]; then
+  odr-dabmux /config/mux.ini
+else
+  odr-dabmux ${argv}
+fi


### PR DESCRIPTION
### Changes
- odr-dabmux opens `/config/mux.ini` file
- Add schedule and workflow_dispatch triggers to the docker-publish action
- Update versions of used github actions
- Rename github secrets
- Switch to debian:bookworm-backports base image
- Use odr-dabmux backports package instead of building it
- Enhance the documentation
